### PR TITLE
Allow non-primary wgpu backends

### DIFF
--- a/graphical/src/wgpu_context.rs
+++ b/graphical/src/wgpu_context.rs
@@ -110,7 +110,7 @@ async fn init_device() -> Result<(wgpu::Instance, wgpu::Device, wgpu::Queue), Co
     let backend = if cfg!(feature = "force_vulkan") {
         wgpu::BackendBit::VULKAN
     } else {
-        wgpu::BackendBit::PRIMARY
+        wgpu::BackendBit::all()
     };
     let instance = wgpu::Instance::new(backend);
     let adapter = instance


### PR DESCRIPTION
The `PRIMARY` `BackendBit` excludes DX11, which causes incompatibility with older hardware or systems that don't run DX12 or Vulkan. Changing it to `all()` allows it to run on those systems.